### PR TITLE
Fix when path have whitespaces + gnome

### DIFF
--- a/bash/wmSetMultimonitorBkgrnd.sh
+++ b/bash/wmSetMultimonitorBkgrnd.sh
@@ -269,6 +269,7 @@ applyBackground () {
     if [ ! -z "$findGnome" ]; then
 	    gsettings set org.gnome.desktop.background picture-options "spanned"
 	    gsettings set org.gnome.desktop.background picture-uri "file://$(readlink -f ${OUTIMG})"
+	    gsettings set org.gnome.desktop.background picture-uri-dark "file://$(readlink -f ${OUTIMG})"
     fi
 }
 


### PR DESCRIPTION
Here is a fix to handle paths and files with whitespaces.
It adds compatibility with gnome (tested on latest Ubuntu)

Hope it helps...